### PR TITLE
RFロジック検証用のseedデータ作成 #4

### DIFF
--- a/rf-repeat-app-backend/db/migrate/20260309104525_create_reservations.rb
+++ b/rf-repeat-app-backend/db/migrate/20260309104525_create_reservations.rb
@@ -3,7 +3,6 @@ class CreateReservations < ActiveRecord::Migration[7.2]
     create_table :reservations do |t|
       t.references :customer, null: false, foreign_key: true
       t.datetime :visited_at, null: false
-
       t.timestamps
     end
   end

--- a/rf-repeat-app-backend/db/seeds.rb
+++ b/rf-repeat-app-backend/db/seeds.rb
@@ -1,9 +1,28 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# ---------------------
+# customersのダミーデータを作成
+# ---------------------
+
+customers = []
+
+20.times do |i|
+  customers << Customer.create!(
+    name: "顧客#{i + 1}"
+  )
+end
+
+puts "customers created"
+
+# ---------------------
+# reservationsのダミーデータを作成
+# ---------------------
+
+20.times do
+  Reservation.create!(
+    customer: customers.sample,
+    visited_at: rand(1..180).days.ago
+  )
+end
+
+puts "reservations created"
+
+puts "seed finished"


### PR DESCRIPTION
What
顧客、予約のダミーデータを追加。
Why
RFランクロジックを実装するためのダミーデータが必要であるため。
