### PR TITLE
Feature/rf logic

### DIFF
--- a/rf-repeat-app-backend/app/models/customer.rb
+++ b/rf-repeat-app-backend/app/models/customer.rb
@@ -1,4 +1,5 @@
 class Customer < ApplicationRecord
   has_many :reservations, dependent: :destroy
+  has_one :rf_score, dependent: :destroy
 end
 

--- a/rf-repeat-app-backend/app/services/rf_rank_calculator.rb
+++ b/rf-repeat-app-backend/app/services/rf_rank_calculator.rb
@@ -46,7 +46,7 @@ class RfRankCalculator
     rf_score.update!(
       visit_count: visit_count,
       last_visit_at: last_visit_at,
-      rf_rank: rank
+      rank: rank
     )
   end
 end


### PR DESCRIPTION
What
RFランク計算サービスを実装

Why
顧客ごとの来店回数・最終来店日をもとにRFランクを算出し
rf_scores テーブルへ保存できるようにするため

Related Issue
#5
