### PR TITLE
✨ RFスコアを計算して更新するタスクを追加

### DIFF
--- a/rf-repeat-app-backend/lib/tasks/rf_score.rake
+++ b/rf-repeat-app-backend/lib/tasks/rf_score.rake
@@ -1,0 +1,7 @@
+namespace :rf do
+  desc "RFスコアを計算して更新するタスク"
+  task update_rf_scores: :environment do
+    RfRankCalculator.call
+    puts "RFスコアの更新が完了しました。"
+  end
+end


### PR DESCRIPTION
What
RFスコア一括更新用のRakeタスクを作成

Why
定期的に全顧客のRFスコアを再計算できるようにするため

Related Issue
#6