### PR TITLE
✨ RFスコアを取得するAPIエンドポイントを追加

### DIFF
--- a/rf-repeat-app-backend/app/controllers/api/v1/rf_scores_controller.rb
+++ b/rf-repeat-app-backend/app/controllers/api/v1/rf_scores_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::RfScoresController < ApplicationController
+  def index
+    # ランク昇順、来店回数降順に設定
+    rf_scores = RfScore.includes(:customer).order(rank: :asc, visit_count: :desc)
+
+    render json: rf_scores.as_json(
+      only: [:visit_count, :last_visit_at, :rank],
+      include: {
+        customer: {
+          only: [:id, :name]
+        }
+      }
+    )
+  end
+end

--- a/rf-repeat-app-backend/config/routes.rb
+++ b/rf-repeat-app-backend/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "health", to: "health#index"
+
+      resources :rf_scores, only: [:index]
     end
   end
 end


### PR DESCRIPTION
What
RFスコア一覧を返すAPIを追加

Why
Next.js側でRFランキング一覧を表示できるようにするため

Related Issue
#7