### PR TITLE
✅ 顧客詳細と予約詳細のリクエストテストを追加 #22

### DIFF
--- a/rf-repeat-app-backend/spec/requests/api/v1/customers_spec.rb
+++ b/rf-repeat-app-backend/spec/requests/api/v1/customers_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Api::V1::Customers", type: :request do
 
       expect(json["name"]).to eq("山田太郎")
     end
+    # 異常系-名前がない場合の顧客作成APIのリクエストテスト
     it "名前がない場合は作成できない" do
       expect {
         post '/api/v1/customers', params: { customer: { name: "" } }
@@ -42,4 +43,33 @@ RSpec.describe "Api::V1::Customers", type: :request do
       expect(names).to include("大阪 一太郎", "大阪 勘太郎")
     end
   end
+  # 正常系-顧客詳細APIのリクエストテスト
+  describe "GET /api/v1/customers/:id" do
+    let!(:customer) { Customer.create!(name: "大阪 一太郎") }
+    let!(:reservation1) { Reservation.create!(customer: customer, visited_at: 1.day.ago) }
+    let!(:reservation2) { Reservation.create!(customer: customer, visited_at: Time.current) }
+    let!(:rf_score) do
+      RfScore.create!(
+        customer: customer,
+        visit_count: 5,
+        last_visit_at: Time.current,
+        rank: "C"
+      )
+    end
+
+    it "顧客の詳細情報を取得できる" do
+      get "/api/v1/customers/#{customer.id}"
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      expect(json["name"]).to eq("大阪 一太郎")
+      expect(json["rf_score"]["visit_count"]).to eq(5)
+      expect(json["rf_score"]["rank"]).to eq("C")
+      reservation_ids = json["reservations"].map { |reservation| reservation["id"] }
+      expect(reservation_ids).to include(reservation1.id, reservation2.id)
+    end
+  end
+
 end


### PR DESCRIPTION
What
- 顧客詳細APIの Request spec を追加
- 予約詳細APIの Request spec を追加
- 顧客詳細レスポンスに含まれる rf_score / reservations の確認を追加
- 予約詳細レスポンスの確認を追加

Why
- 顧客詳細画面と予約詳細画面が前提としているレスポンス形式をテストで保証するため
- 詳細系APIの動作を安定させるため

確認内容
- GET /api/v1/customers/:id で顧客詳細を取得できること
- 顧客詳細レスポンスに rf_score と reservations が含まれること
- GET /api/v1/reservations/:id で予約詳細を取得できること

Related Issue
#22