### PR TITLE
✅ 顧客IDを指定した場合に対象顧客のみを取得するテストを追加 #31

### DIFF
--- a/rf-repeat-app-backend/spec/requests/api/v1/customers_spec.rb
+++ b/rf-repeat-app-backend/spec/requests/api/v1/customers_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe "Api::V1::Customers", type: :request do
       names = json.map { |customer| customer["name"] }
       expect(names).to include("大阪 一太郎", "大阪 勘太郎")
     end
+
+    it "ids を指定した場合は対象顧客だけを取得できる" do
+      customer3 = Customer.create!(name: "東京 三太郎")
+
+      get "/api/v1/customers", params: { ids: "#{customer1.id},#{customer3.id}" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      expect(json).to be_an(Array)
+
+      ids = json.map { |customer| customer["id"] }
+      names = json.map { |customer| customer["name"] }
+
+      expect(ids).to contain_exactly(customer1.id, customer3.id)
+      expect(names).to contain_exactly("大阪 一太郎", "東京 三太郎")
+      expect(ids).not_to include(customer2.id)
+    end
   end
   # 正常系-顧客詳細APIのリクエストテスト
   describe "GET /api/v1/customers/:id" do


### PR DESCRIPTION
What
- `GET /api/v1/customers?ids=...` の request spec を追加
- ids 指定時に対象顧客のみ取得できることを確認するテストを追加
- ids 未指定時に通常の顧客一覧取得ができることを確認する

Why
- RFM分析表のセルから対象顧客一覧へ遷移する機能の動作を保証するため
- 顧客一覧APIの ids 絞り込み挙動をテストで明確にするため

確認内容
- ids 指定時に対象顧客のみ返ること
- 指定していない顧客が含まれないこと
- ids 未指定時は通常の一覧取得になること

Related Issue
#31