### PR TITLE
🧹 不要なヘルスチェック関連を削除

### DIFF
--- a/rf-repeat-app-backend/app/controllers/api/v1/health_controller.rb
+++ b/rf-repeat-app-backend/app/controllers/api/v1/health_controller.rb
@@ -1,5 +1,0 @@
-class Api::V1::HealthController < ApplicationController
-  def index
-    render json: { status: "ok" }
-  end
-end

--- a/rf-repeat-app-backend/config/routes.rb
+++ b/rf-repeat-app-backend/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get "health", to: "health#index"
-
       resources :rf_scores, only: [:index]
       resources :customers, only: [:create, :index, :show] 
       resources :reservations, only: [:create, :index, :show]


### PR DESCRIPTION
What
- 不要になっていたヘルスチェック用コントローラーを削除
- 不要になっていたヘルスチェック用ルーティングを削除

Why
- 現在のアプリで使用していない初期機能を整理するため
- 不要な画面や導線を減らして構成を分かりやすくするため
- 今後の機能追加や保守をしやすくするため

確認内容
- 主要画面の導線に影響がないこと
- 不要なヘルスチェックルートが削除されていること
- 既存の顧客 / 予約 / RF / RFM関連機能が正常に動作すること

Related Issue
#36