### PR TITLE
fix: active_totalがZ/Nを含んでいた問題を修正

### DIFF
--- a/rf-repeat-app-backend/app/controllers/api/v1/customers_controller.rb
+++ b/rf-repeat-app-backend/app/controllers/api/v1/customers_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::CustomersController < ApplicationController
   def show
     customer = Customer.includes(:reservations).find(params[:id])
 
-    rf_result = RfRankRule.call(
+    rf_result = Rf::Calculators::RankRule.call(
     reservations: customer.reservations,
     base_date: Time.current
   )

--- a/rf-repeat-app-backend/app/models/rf_rank_master.rb
+++ b/rf-repeat-app-backend/app/models/rf_rank_master.rb
@@ -37,7 +37,7 @@ class RfRankMaster
     },
     {
       key: "N",
-      label: "対象外",
+      label: "Nランク",
       description: "来店履歴がない顧客です。",
       order: 7
     }
@@ -57,5 +57,17 @@ class RfRankMaster
 
   def self.description_for(key)
     RANKS.find { |rank| rank[:key] == key }&.dig(:description)
+  end
+
+  def self.active_keys
+    %w[A B C D E]
+  end
+
+  def self.rank_out_key
+    "Z"
+  end
+
+  def self.out_of_scope_key
+    "N"
   end
 end

--- a/rf-repeat-app-backend/app/services/rf/builders/rank_summary.rb
+++ b/rf-repeat-app-backend/app/services/rf/builders/rank_summary.rb
@@ -22,14 +22,11 @@ module Rf
 
         {
           ranks: build_ranks(grouped),
-          active_total: RfRankMaster.all.sum do |rank|
-            key = rank[:key]
-            next 0 if ["Z", "N"].include?(key)
-
+          active_total: RfRankMaster.active_keys.sum do |key|
             grouped[key].to_i
           end,
-          rank_out_total: grouped["Z"].to_i,
-          out_of_scope_total: grouped["N"].to_i,
+          rank_out_total: grouped[RfRankMaster.rank_out_key].to_i,
+          out_of_scope_total: grouped[RfRankMaster.out_of_scope_key].to_i,  
           all_customers_total: Customer.count
         }
       end

--- a/rf-repeat-app-frontend/lib/rf-master-format.ts
+++ b/rf-repeat-app-frontend/lib/rf-master-format.ts
@@ -49,8 +49,8 @@ export function rankLabel(rank: string): string {
       return "E";
     case "Z":
       return "Z";
-    case "対象外":
-      return "集計期間対象外";
+    case "N":
+      return "N";
     default:
       return rank;
   }
@@ -72,19 +72,19 @@ export function formatDate(dateString: string | null) {
   return date.toLocaleDateString("ja-JP");
 }
 
-export function rowLabel(row: string): string {
-  switch (row) {
-    case "recent":
-      return "1年以内";
-    case "middle":
-      return "1年以上3年以内";
-    case "old":
-      return "3年以上5年以内";
-    case "inactive":
-      return "5年以上10年以内";
-    case "out_of_scope":
-      return "対象外";
-    default:
-      return "未設定";
-  }
-}
+// export function rowLabel(row: string): string {
+//   switch (row) {
+//     case "recent":
+//       return "1年以内";
+//     case "middle":
+//       return "1年以上3年以内";
+//     case "old":
+//       return "3年以上5年以内";
+//     case "inactive":
+//       return "5年以上10年以内";
+//     case "out_of_scope":
+//       return "対象外";
+//     default:
+//       return "未設定";
+//   }
+// }


### PR DESCRIPTION
## What

* `active_total` の集計対象を **A〜E のみ**に修正
* `rank_out_total` を **Z（休眠顧客）**、`out_of_scope_total` を **N（対象外）**として明確に分離
* ランク分類ロジックを `RfRankMaster` に集約（`active_keys` などを追加）
* spec を現在の集計仕様に合わせて更新

## Why

* `RfRankMaster.keys` をそのまま利用していたため、Z/N が `active_total` に含まれていた
* 仕様上の定義（アクティブ＝A〜E）と実装が不一致だった
* 分析結果の正確性と一貫性を担保するため

Closes #60 