### PR TITLE
fix: RSpecのnamespaceエラーとRF更新処理を修正

### DIFF
--- a/rf-repeat-app-backend/app/jobs/rf_score_update_job.rb
+++ b/rf-repeat-app-backend/app/jobs/rf_score_update_job.rb
@@ -5,6 +5,6 @@ class RfScoreUpdateJob < ApplicationJob
   # 予約された時間に実行されるジョブスイッチ
   def perform(customer_id)
     customer = Customer.find(customer_id)
-    RfRankCalculator.update_customer(customer)
+    Rf::Calculators::RankCalculator.update_customer(customer)
   end
 end

--- a/rf-repeat-app-backend/app/services/rf/calculators/rank_calculator.rb
+++ b/rf-repeat-app-backend/app/services/rf/calculators/rank_calculator.rb
@@ -1,5 +1,5 @@
 module Rf
-  module Calculator
+  module Calculators
     class RankCalculator
       # 全顧客のRFスコアを更新する関数
       def self.call
@@ -11,11 +11,11 @@ module Rf
       # 顧客のRFスコアを更新する関数
       def self.update_customer(customer)
         reservations = Reservation.where(customer_id: customer.id)
-        base_date = Rf::BaseDate.resolve(nil)
+        base_date = Rf::Shared::BaseDate.resolve(nil)
 
         # 共通ルールに判定を委譲する
         # ここで rank / 最終来店日 / 直近1年件数 などをまとめて取得する
-        result = RfRankRule.call(
+        result = Rf::Calculators::RankRule.call(
           reservations: reservations,
           base_date: base_date  
         )

--- a/rf-repeat-app-backend/spec/jobs/rf_score_update_job_spec.rb
+++ b/rf-repeat-app-backend/spec/jobs/rf_score_update_job_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RfScoreUpdateJob, type: :job do
     let(:customer) { Customer.create!(name: "顧客A") }
 
     it "対象顧客を取得してRF更新処理を呼ぶ" do
-      # RfRankCalculator.update_customerがcustomerを引数に呼ばれることを期待する
-      expect(RfRankCalculator).to receive(:update_customer).with(customer)
+      # Rf::Calculators::RankCalculator.update_customerがcustomerを引数に呼ばれることを期待する
+      expect(Rf::Calculators::RankCalculator).to receive(:update_customer).with(customer)
       # perform_nowで今すぐ同期を実行する
       described_class.perform_now(customer.id)
     end

--- a/rf-repeat-app-backend/spec/services/rf_rank_calculator_spec.rb
+++ b/rf-repeat-app-backend/spec/services/rf_rank_calculator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RfRankCalculator, type: :service do
+RSpec.describe Rf::Calculators::RankCalculator, type: :service do
   include ActiveSupport::Testing::TimeHelpers
   describe ".update_customer" do
     around do |example|

--- a/rf-repeat-app-backend/spec/services/rf_rank_summary_spec.rb
+++ b/rf-repeat-app-backend/spec/services/rf_rank_summary_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RfRankSummary, type: :service do
+RSpec.describe Rf::Builders::RankSummary, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
   describe ".call" do

--- a/rf-repeat-app-backend/spec/services/rf_transition_builder_spec.rb
+++ b/rf-repeat-app-backend/spec/services/rf_transition_builder_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RfTransitionBuilder, type: :service do
+RSpec.describe Rf::Builders::TransitionBuilder, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
   describe ".call" do


### PR DESCRIPTION
## What

* RSpecの未定義定数エラーを修正
* RF更新処理（Job / service）のクラス参照を修正
* namespaceの不整合を解消

## Why

* クラスの名前空間変更により、specおよび更新処理で未定義定数エラーが発生していたため

## 対応内容

* specのクラス参照を修正
* RankCalculatorのnamespaceを修正
* BaseDate / RankRuleの参照を正しいモジュールに統一

## 動作確認

* `bundle exec rspec` が全て通ることを確認

## 影響範囲

* RFランキング更新処理
* テスト全体

Closes #66 
