### PR TITLE
feat: TOPダッシュボードを追加し、RFマスタ表示を最新ロジックに統一

### DIFF
--- a/rf-repeat-app-backend/app/controllers/api/v1/rf_masters_controller.rb
+++ b/rf-repeat-app-backend/app/controllers/api/v1/rf_masters_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RfMastersController < ApplicationController
   def index
-    rf_masters = RfMaster.order(:position)
+    rf_masters = RfRankMaster.for_api
     render json: rf_masters, status: :ok
   end
 end

--- a/rf-repeat-app-backend/app/models/rf_rank_master.rb
+++ b/rf-repeat-app-backend/app/models/rf_rank_master.rb
@@ -1,62 +1,90 @@
 class RfRankMaster
+  AGGREGATION_PERIOD_DAYS = 1_825
+  THREE_MONTHS_DAYS = 90
+  SIX_MONTHS_DAYS = 180
+  ONE_YEAR_DAYS = 365
+  TWO_YEARS_DAYS = 730
+
   RANKS = [
     { key: "A",
       label: "Aランク",
       description: "直近3ヶ月以内に来店があり、直近1年で6回以上来店している優良顧客です。",
+      min_visit_count: 6,
+      max_visit_count: nil,
+      target_period_days: ONE_YEAR_DAYS,
+      recent_visit_within_days: THREE_MONTHS_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 1
     },
     {
       key: "B",
       label: "Bランク",
       description: "直近6ヶ月以内に来店があり、直近1年で3〜5回来店している安定顧客です。",
+      min_visit_count: 3,
+      max_visit_count: 5,
+      target_period_days: ONE_YEAR_DAYS,
+      recent_visit_within_days: SIX_MONTHS_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 2
     },
     {
       key: "C",
       label: "Cランク",
       description: "直近1年以内に来店があり、直近1年で1〜2回の来店にとどまる顧客です。",
+      min_visit_count: 1,
+      max_visit_count: 2,
+      target_period_days: ONE_YEAR_DAYS,
+      recent_visit_within_days: ONE_YEAR_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 3
     },
     {
       key: "D",
       label: "Dランク",
       description: "1年以上来店がない離反予備群の顧客です。",
+      min_visit_count: 1,
+      max_visit_count: nil,
+      target_period_days: ONE_YEAR_DAYS,
+      min_days_since_last_visit: ONE_YEAR_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 4
     },
     {
       key: "E",
       label: "Eランク",
       description: "初回来店から3ヶ月以内で、まだ1回のみ来店している新規顧客です。",
+      min_visit_count: 1,
+      max_visit_count: 1,
+      target_period_days: THREE_MONTHS_DAYS,
+      first_visit_within_days: THREE_MONTHS_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 5
     },
     {
       key: "Z",
       label: "Zランク",
       description: "直近5年で2回以下かつ2年以上来店がない休眠顧客です。",
+      min_visit_count: 0,
+      max_visit_count: 2,
+      target_period_days: AGGREGATION_PERIOD_DAYS,
+      min_days_since_last_visit: TWO_YEARS_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 6
     },
     {
       key: "N",
       label: "Nランク",
       description: "来店履歴がない顧客です。",
+      min_visit_count: 0,
+      max_visit_count: 0,
+      target_period_days: AGGREGATION_PERIOD_DAYS,
+      aggregation_period_days: AGGREGATION_PERIOD_DAYS,
       order: 7
     }
   ].freeze
 
-  def self.keys
-    RANKS.map { |rank| rank[:key] }
-  end
-
   def self.all
     RANKS
-  end
-
-  def self.label_for(key)
-    RANKS.find { |rank| rank[:key] == key }&.dig(:label)
-  end
-
-  def self.description_for(key)
-    RANKS.find { |rank| rank[:key] == key }&.dig(:description)
   end
 
   def self.active_keys
@@ -69,5 +97,23 @@ class RfRankMaster
 
   def self.out_of_scope_key
     "N"
+  end
+
+  def self.for_api
+    RANKS.map.with_index(1) do |rank, index|
+      {
+        id: index,
+        rank: rank[:key],
+        min_visit_count: rank[:min_visit_count],
+        max_visit_count: rank[:max_visit_count],
+        aggregation_period_days: rank[:aggregation_period_days],
+        target_period_days: rank[:target_period_days],
+        position: rank[:order],
+        key: rank[:key],
+        label: rank[:label],
+        description: rank[:description],
+        order: rank[:order]
+      }
+    end
   end
 end

--- a/rf-repeat-app-backend/app/services/rf/builders/rank_movement_builder.rb
+++ b/rf-repeat-app-backend/app/services/rf/builders/rank_movement_builder.rb
@@ -124,10 +124,6 @@ module Rf
 
       private
 
-      def base_month
-        Time.current.prev_month
-      end
-
       def build_empty_matrix
         ranks.each_with_object({}) do |from_rank, outer_hash|
           outer_hash[from_rank[:key]] = ranks.each_with_object({}) do |to_rank, inner_hash|

--- a/rf-repeat-app-backend/app/services/rf/calculators/rank_rule.rb
+++ b/rf-repeat-app-backend/app/services/rf/calculators/rank_rule.rb
@@ -2,17 +2,13 @@ module Rf
   module Calculators
     class RankRule
       # 集計期間: 5年
-      AGGREGATION_PERIOD_DAYS = 1825
+      AGGREGATION_PERIOD_DAYS = RfRankMaster::AGGREGATION_PERIOD_DAYS
 
       # 判定用期間
-      THREE_MONTHS_DAYS = 90
-      SIX_MONTHS_DAYS   = 180
-      ONE_YEAR_DAYS = 365
-      TWO_YEARS_DAYS = 730
-
-      def self.aggregation_period
-        AGGREGATION_PERIOD_DAYS.days
-      end
+      THREE_MONTHS_DAYS = RfRankMaster::THREE_MONTHS_DAYS
+      SIX_MONTHS_DAYS   = RfRankMaster::SIX_MONTHS_DAYS
+      ONE_YEAR_DAYS = RfRankMaster::ONE_YEAR_DAYS
+      TWO_YEARS_DAYS = RfRankMaster::TWO_YEARS_DAYS
 
       # クラスメソッドで呼び出せるようにする
       # 例: RfRankRule.call(reservations: reservations, base_date: Time.current)
@@ -170,4 +166,3 @@ module Rf
     end
   end
 end
-

--- a/rf-repeat-app-backend/spec/requests/api/v1/rf_masters_spec.rb
+++ b/rf-repeat-app-backend/spec/requests/api/v1/rf_masters_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::RfMasters", type: :request do
   describe "GET /api/v1/rf_masters" do
-    let!(:rf_master1) { RfMaster.create!(rank: "A", min_visit_count: 10, min_days_since_last_visit: 30, position: 1) }
-    let!(:rf_master2) { RfMaster.create!(rank: "B", min_visit_count: 5, min_days_since_last_visit: 15, position: 2) }
-
     it "RFマスタ一覧を取得できる" do
       get "/api/v1/rf_masters"
 
@@ -13,10 +10,25 @@ RSpec.describe "Api::V1::RfMasters", type: :request do
       json = JSON.parse(response.body)
 
       expect(json).to be_an(Array)
-      expect(json.size).to eq(2)
+      expect(json.size).to eq(7)
 
       ranks = json.map { |rf_master| rf_master["rank"] }
-      expect(ranks).to include("A", "B")
+      expect(ranks).to eq(%w[A B C D E Z N])
+
+      a_rank = json.find { |rf_master| rf_master["rank"] == "A" }
+      z_rank = json.find { |rf_master| rf_master["rank"] == "Z" }
+
+      aggregate_failures do
+        expect(a_rank["min_visit_count"]).to eq(6)
+        expect(a_rank["max_visit_count"]).to be_nil
+        expect(a_rank["aggregation_period_days"]).to eq(1825)
+        expect(a_rank["target_period_days"]).to eq(365)
+        expect(a_rank["position"]).to eq(1)
+
+        expect(z_rank["min_visit_count"]).to eq(0)
+        expect(z_rank["max_visit_count"]).to eq(2)
+        expect(z_rank["target_period_days"]).to eq(1825)
+      end
     end
   end
 

--- a/rf-repeat-app-frontend/app/page.tsx
+++ b/rf-repeat-app-frontend/app/page.tsx
@@ -1,3 +1,95 @@
-export default function Home() {
-  return <div>TOPページです。</div>;
+import { KpiGrid } from "@/components/kpi/kpi_grid";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+
+type Reservation = {
+  id: number;
+  visited_at: string;
+  customer: {
+    id: number;
+    name: string;
+  };
+};
+
+type RankSummary = {
+  rank: string;
+  count: number;
+};
+
+type RfRankSummaryResponse = {
+  ranks: RankSummary[];
+  active_total: number;
+  rank_out_total: number;
+  out_of_scope_total: number;
+  all_customers_total: number;
+};
+
+// 今日判定
+function isToday(dateString: string) {
+  const date = new Date(dateString);
+  const today = new Date();
+
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  );
+}
+
+// API取得
+async function getSummary(): Promise<RfRankSummaryResponse> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  const res = await fetch(`${baseUrl}/api/v1/rf_rank_summaries`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error("summary取得失敗");
+
+  return res.json();
+}
+
+async function getReservations(): Promise<Reservation[]> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  const res = await fetch(`${baseUrl}/api/v1/reservations`, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) throw new Error("reservations取得失敗");
+
+  return res.json();
+}
+
+// 👇 ここが重要（async）
+export default async function Home() {
+  const summary = await getSummary();
+  const reservations = await getReservations();
+
+  const todayReservations = reservations.filter((r) => isToday(r.visited_at));
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* KPI */}
+      <KpiGrid
+        kpis={[
+          { title: "今日の予約", value: `${todayReservations.length}件` },
+          { title: "登録顧客", value: `${summary.all_customers_total}人` },
+          { title: "アクティブ顧客", value: `${summary.active_total}人` },
+          { title: "休眠顧客", value: `${summary.rank_out_total}人` },
+        ]}
+      />
+
+      {/* RFサマリー */}
+      <Table>
+        <TableBody>
+          {summary.ranks.map((rank) => (
+            <TableRow key={rank.rank}>
+              <TableCell>{rank.rank}</TableCell>
+              <TableCell>{rank.count}人</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
 }

--- a/rf-repeat-app-frontend/app/setting/rf-masters/page.tsx
+++ b/rf-repeat-app-frontend/app/setting/rf-masters/page.tsx
@@ -17,6 +17,7 @@ type RfMaster = {
   max_visit_count: number | null;
   aggregation_period_days: number;
   target_period_days: number;
+  description: string;
   position: number;
   created_at: string;
   updated_at: string;
@@ -62,7 +63,7 @@ export default async function RfMastersPage() {
                   <TableRow>
                     <TableHead>ランク</TableHead>
                     <TableHead>集計期間</TableHead>
-                    <TableHead>判定対象期間</TableHead>
+                    <TableHead>判定条件</TableHead>
                     <TableHead>来店回数条件</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -76,8 +77,7 @@ export default async function RfMastersPage() {
                         {daysToYearsText(rfMaster.aggregation_period_days)}
                       </TableCell>
                       <TableCell>
-                        判定対象期間:
-                        {daysToYearsText(rfMaster.target_period_days)}以内
+                        {rfMaster.description}
                       </TableCell>
                       <TableCell>
                         来店回数:

--- a/rf-repeat-app-frontend/app/setting/rf-masters/page.tsx
+++ b/rf-repeat-app-frontend/app/setting/rf-masters/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -65,8 +64,6 @@ export default async function RfMastersPage() {
                     <TableHead>集計期間</TableHead>
                     <TableHead>判定対象期間</TableHead>
                     <TableHead>来店回数条件</TableHead>
-                    <TableHead>条件の意味</TableHead>
-                    <TableHead>操作</TableHead>
                   </TableRow>
                 </TableHeader>
 
@@ -88,15 +85,6 @@ export default async function RfMastersPage() {
                           rfMaster.min_visit_count,
                           rfMaster.max_visit_count,
                         )}
-                      </TableCell>
-                      <TableCell className="whitespace-normal"></TableCell>
-                      <TableCell>
-                        <Link
-                          href={`/setting/rf-masters/${rfMaster.id}/edit`}
-                          className="underline"
-                        >
-                          編集
-                        </Link>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/rf-repeat-app-frontend/lib/rf-master-format.ts
+++ b/rf-repeat-app-frontend/lib/rf-master-format.ts
@@ -16,19 +16,15 @@ export function formatVisitRange(min: number, max: number | null) {
   return `${min}回〜${max}回`;
 }
 
-export function formatTargetPeriod(days: number) {
-  return `直近${daysToYearsText(days)}以内`;
-}
-
 // ランク色のフォーマット
-export const RANK_COLOR_MAP: Record<string, string> = {
+const RANK_COLOR_MAP: Record<string, string> = {
   A: "bg-green-600",
   B: "bg-green-300",
   C: "bg-blue-300",
   D: "bg-yellow-300",
   E: "bg-orange-300",
   Z: "bg-gray-300",
-  対象外: "bg-slate-300",
+  N: "bg-slate-300",
 };
 
 export function rankColor(rank: string): string {
@@ -71,20 +67,3 @@ export function formatDate(dateString: string | null) {
   const date = new Date(dateString);
   return date.toLocaleDateString("ja-JP");
 }
-
-// export function rowLabel(row: string): string {
-//   switch (row) {
-//     case "recent":
-//       return "1年以内";
-//     case "middle":
-//       return "1年以上3年以内";
-//     case "old":
-//       return "3年以上5年以内";
-//     case "inactive":
-//       return "5年以上10年以内";
-//     case "out_of_scope":
-//       return "対象外";
-//     default:
-//       return "未設定";
-//   }
-// }


### PR DESCRIPTION
## What

### 1. TOPダッシュボードの追加
- TOPページを新規実装
- 以下の情報を可視化
  - 今日の予約件数
  - 登録顧客数
  - アクティブ顧客数
  - 休眠顧客数
- RFランク別人数をテーブル表示
- `/api/v1/rf_rank_summaries` を利用
- `/api/v1/reservations` を利用して当日予約を抽出

---

### 2. RFマスタ表示の修正
- 旧ロジックベースの表示を廃止
- `RfRankMaster` の定義をそのままAPI経由で表示する構成に変更
- 表示ロジックとドメインロジックの乖離を解消

---

### 3. 軽微修正
- Tableコンポーネントのimport不備を修正

---

## Why

### TOPページについて
RF分析を「確認するだけ」で終わらせず、

- 今日の営業状況の把握
- 顧客状態（アクティブ / 休眠）の即時確認

を1画面で行えるようにするため。

飲食店運用では「今日何を見るか」が重要なため、
ダッシュボードとしてTOPページを追加。

---

### RFマスタ修正について
旧ロジックと現在のランク定義に差異があり、
表示内容と実際の判定ロジックが一致していなかった。

そのため、

- 表示は `RfRankMaster` に完全依存
- ロジックとUIの不整合を解消

する形に修正。

---

## 動作確認

- TOPページでKPIが表示されること
- 当日の予約件数が正しくカウントされること
- RFランク別人数が正しく表示されること
- RFマスタ画面が最新ロジックに基づいて表示されること
